### PR TITLE
Hacer responsivas tarjetas de profersionales

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -170,12 +170,14 @@ button:hover {
 /* ====== Profesionales ====== */
 .profesional-card {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 45px;
-    padding: 10px 30px;
+    gap: 20px;
+    padding: 20px 15px;
     border: 1px solid #ddd;
     border-radius: 8px;
-    margin-bottom: 10px;
+    margin-bottom: 20px;
+    text-align: center;
 }
 
 .card-profile {
@@ -355,3 +357,13 @@ footer {
     background: rgba(0,0,0,0.4); /* oscurece para que se lea el texto */
 }
 
+/* ---- Estilos para pantallas de 768px en adelante ---- */
+@media (min-width: 768px) {
+    .profesional-card {
+        flex-direction: row;
+        align-items: center;
+        gap: 45px;
+        padding: 10px 30px;
+        text-align: left;
+    }
+}


### PR DESCRIPTION
Modificar el CSS de las tarjetas de profesionales para que la foto y la descripción se apilen verticalmente en móviles.
Antes:
<img width="412" height="750" alt="antes" src="https://github.com/user-attachments/assets/b37b1669-3cf8-4c41-82ac-d8f8eb258597" />

Después
<img width="417" height="734" alt="despues" src="https://github.com/user-attachments/assets/58ca4c15-9c1f-4982-8267-22b5847b00a4" />

- Se hace sección mobile first
- Se agrega mediaquery para pantallas grandes.