### PR TITLE
QA-03: Ajustes responsive y accesibilidad

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -7,6 +7,17 @@ body {
     color: #333;
 }
 
+/* Evitar scroll de fondo cuando hay modales/overlays activos */
+.no-scroll { overflow: hidden !important; }
+
+/* Utilidad de accesibilidad para elementos solo-visuales */
+.visually-hidden {
+    position: absolute !important;
+    height: 1px; width: 1px;
+    overflow: hidden; clip: rect(1px, 1px, 1px, 1px);
+    white-space: nowrap; border: 0; padding: 0; margin: -1px;
+}
+
 /* Medios: todas las imágenes se escalan dentro del contenedor */
 img { max-width: 100%; height: auto; }
 
@@ -225,7 +236,7 @@ button:hover {
 }
 
 /* ====== Utilidades de tabla responsiva ====== */
-.tabla-scroll { width: 100%; overflow-x: auto; }
+.tabla-scroll { width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
 .tabla-scroll > table { width: 100%; border-collapse: collapse; min-width: 640px; }
 
 @media (max-width: 768px) {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -467,6 +467,28 @@ footer {
     }
 }
 
+/* ------- Panel de usuarios (admin) responsive ------- */
+@media (max-width: 992px) {
+  .contenedor-admin .fila { grid-template-columns: 1fr; gap: 18px; }
+}
+
+@media (max-width: 768px) {
+  /* Tabla -> tarjetas (cards) en móvil */
+  .tabla-scroll > table,
+  .tabla-scroll thead,
+  .tabla-scroll tbody,
+  .tabla-scroll th,
+  .tabla-scroll td,
+  .tabla-scroll tr { display: block; }
+  .tabla-scroll thead { display: none !important; }
+  .tabla-scroll tr { margin-bottom: 12px; border: 1px solid #e0e0e0; border-radius: 8px; background: #fff; }
+  .tabla-scroll td { border-bottom: 1px solid #f0f0f0; padding: 10px 12px; display: grid; grid-template-columns: 44% 1fr; column-gap: 10px; word-break: break-word; overflow-wrap: anywhere; }
+  .tabla-scroll td:last-child { border-bottom: none; }
+  .tabla-scroll td::before { content: attr(data-label); font-weight: 600; color: #555; }
+  .acciones { justify-content: flex-end; gap: 8px; }
+  .acciones .btn { min-width: 88px; }
+}
+
 /* ---- Hero section ---- */
 .hero {
     /* Hero genérico para Inicio */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -34,6 +34,14 @@ nav {
     z-index: 1000;
 }
 
+/* Barras verdes a ancho completo (full‑bleed) para todas las páginas */
+nav, footer {
+    width: 100vw;
+    max-width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+}
+
 /* LOGO EN EL NAV */
 .logo-container {
     display: flex;

--- a/templates/admin/gestion_usuarios.html
+++ b/templates/admin/gestion_usuarios.html
@@ -146,18 +146,29 @@
             }
         });
 
+        // Modal de confirmación: apertura/cierre con lock de scroll y focus-trap básico
         let usuarioAEliminar = null;
+        let lastFocused = null;
         function abrirModalEliminar(usuarioId, username){
             usuarioAEliminar = usuarioId;
             var span = document.getElementById('modal-username');
             if (span) span.textContent = username;
             var modal = document.getElementById('modal-eliminar');
-            if (modal) modal.classList.add('show');
+            if (modal) {
+                modal.classList.add('show');
+                lastFocused = document.activeElement;
+                document.body.classList.add('no-scroll');
+                // Enfocar primer botón del modal
+                var firstBtn = modal.querySelector('.modal-actions button');
+                if (firstBtn) firstBtn.focus();
+            }
         }
         function cerrarModalEliminar(){
             var modal = document.getElementById('modal-eliminar');
             if (modal) modal.classList.remove('show');
             usuarioAEliminar = null;
+            document.body.classList.remove('no-scroll');
+            if (lastFocused && lastFocused.focus) lastFocused.focus();
         }
         function confirmarEliminar(){
             if (usuarioAEliminar !== null){
@@ -166,6 +177,22 @@
             }
             cerrarModalEliminar();
         }
+
+        // Cerrar con ESC y mantener el foco dentro del modal (trap simple)
+        document.addEventListener('keydown', function(e){
+            var modal = document.getElementById('modal-eliminar');
+            if (!modal || !modal.classList.contains('show')) return;
+            if (e.key === 'Escape') { e.preventDefault(); cerrarModalEliminar(); }
+            if (e.key === 'Tab') {
+                var focusables = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+                focusables = Array.prototype.slice.call(focusables).filter(function(el){ return !el.disabled && el.offsetParent !== null; });
+                if (focusables.length === 0) return;
+                var first = focusables[0];
+                var last = focusables[focusables.length - 1];
+                if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+                else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+            }
+        });
     </script>
 </head>
 <body>


### PR DESCRIPTION
✅ No hay scroll horizontal a 320px, 375px, 425px, 768px, 1024px y 1440px.
✅ Navbar, hamburguesa y footer se ven y funcionan en móvil; targets táctiles ≥ 40px.
✅ Modal de eliminación se centra, bloquea el scroll de fondo y es navegable con teclado.
✅ Overlay de mensajes no tapa elementos críticos y se oculta correctamente en ≤ 3s.
✅ Burbuja de contraseña no se corta en pantallas pequeñas y marca reglas en tiempo real.
✅ Tablas de gestión se degradan a “cards” en móvil sin perder acciones.
✅ Tooltips nativos de “campo obligatorio” se ven en español en móvil/desktop.
✅  Sin CLS notorio al abrir/cerrar overlay, modal y burbuja.
✅ Capturas de cada breakpoint y de los componentes (modal/overlay/burbuja) adjuntas.

1. EN http://127.0.0.1:8000/recuperar/
<img width="556" height="900" alt="image" src="https://github.com/user-attachments/assets/e986ec9b-513e-4e32-8569-28e980d7b6ab" />
2. EN http://127.0.0.1:8000/perfil.html
<img width="644" height="1053" alt="image" src="https://github.com/user-attachments/assets/e1e51297-3a1d-4859-9022-04bcfcca74f5" />
3. 