### PR TITLE
feat(api-04): agregar listado de pacientes

### DIFF
--- a/clinica_project/urls.py
+++ b/clinica_project/urls.py
@@ -19,5 +19,6 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/', include('gestion.api.urls')),
     path('', include('gestion.urls')),
 ]

--- a/gestion/api/serializers.py
+++ b/gestion/api/serializers.py
@@ -1,0 +1,25 @@
+from rest_framework import serializers
+
+from ..models import Paciente
+
+
+class PacienteSerializer(serializers.ModelSerializer):
+    """Serializa la informacion basica del paciente junto a los datos del usuario."""
+
+    id = serializers.IntegerField(source='usuario.id', read_only=True)
+    nombre = serializers.CharField(source='usuario.first_name')
+    apellidos = serializers.CharField(source='usuario.last_name')
+    email = serializers.EmailField(source='usuario.email')
+
+    class Meta:
+        model = Paciente
+        fields = [
+            'id',
+            'rut',
+            'nombre',
+            'apellidos',
+            'email',
+            'fecha_nacimiento',
+            'direccion',
+            'celular',
+        ]

--- a/gestion/api/urls.py
+++ b/gestion/api/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from .views import PacienteListView
+
+app_name = 'gestion_api'
+
+urlpatterns = [
+    path('pacientes/', PacienteListView.as_view(), name='pacientes-lista'),
+]

--- a/gestion/api/views.py
+++ b/gestion/api/views.py
@@ -1,0 +1,21 @@
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.generics import ListAPIView
+from rest_framework.permissions import IsAuthenticated
+
+from ..models import Paciente
+from .serializers import PacienteSerializer
+
+
+class PacienteListView(ListAPIView):
+    """Entrega el listado de pacientes para consumo externo."""
+
+    serializer_class = PacienteSerializer
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        # Se usa select_related para evitar consultas extra al tomar datos del usuario
+        return Paciente.objects.select_related('usuario').order_by(
+            'usuario__first_name',
+            'usuario__last_name',
+        )


### PR DESCRIPTION
- [x] Error 401 es exactamente lo que se espera cuando se llama al endpoint sin credenciales.
<img width="1114" height="703" alt="image" src="https://github.com/user-attachments/assets/11cca39a-d829-4133-979c-e66a22e339bc" />
<img width="1124" height="892" alt="image" src="https://github.com/user-attachments/assets/0c20ebe0-f4a1-458c-a93c-ae4f260a5dfe" />


- [x] Para obtener la respuesta 200 se necesita un token:
-   Genera token (si no existe):
` python manage.py drf_create_token <usuario>` sin las "<>" como `superadmin` por ejemplo.
 Copiar el valor que se imprime. 
por ejemplo ` 75e27f6886d481cb501cbf6968e40cad30532df9`
-   En Postman agrega en Headers:
 `Authorization` → `Token TU_TOKEN`. Aca se reemplaza por el token asignado anteriormente y antecedido de un 'Token'.
-  Reenvíar la petición GET a http://127.0.0.1:8000/api/pacientes/.
      Con el header, deberías ver 200 OK y la lista de pacientes.

<img width="1087" height="835" alt="image" src="https://github.com/user-attachments/assets/e4d40205-5e1c-4c06-9725-5819684f2ca0" />
<img width="1136" height="907" alt="image" src="https://github.com/user-attachments/assets/16dba53a-bba2-4ad5-805c-562a71f094d3" />
